### PR TITLE
Update UIImage+SwiftyGif.swift

### DIFF
--- a/SwiftyGif/UIImage+SwiftyGif.swift
+++ b/SwiftyGif/UIImage+SwiftyGif.swift
@@ -217,7 +217,7 @@ public extension UIImage {
           displayRefreshFactors.append(UIScreen.main.maximumFramesPerSecond)
         }
 
-        if displayRefreshFactors[0] != 60 {
+        if let first = displayRefreshFactors.first, first != 60 {
           // Append 60 if needed.
           displayRefreshFactors.append(60)
         }


### PR DESCRIPTION
fix: swift index out of range on device lower than iOS 10.3